### PR TITLE
Bundle fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
 </div>
 
 <div style="width:464px; margin: 20px;">
-	<div class="juju-card" data-id="mediawiki-scalable"></div>
+	<div class="juju-card" data-id="~kubernetes/bundle/kubernetes-cluster"></div>
 </div>
 
 <div style="width:221px; margin: 20px;">
@@ -19,7 +19,7 @@
 </div>
 
 <div style="width:464px; margin: 20px;">
-	<div class="juju-card" data-id="juju-gui"></div>
+	<div class="juju-card" data-id="~asanjar/trusty/hdp-tez"></div>
 </div>
 
 <div style="width:221px; margin: 20px;">

--- a/src/js/juju-embed.js
+++ b/src/js/juju-embed.js
@@ -152,11 +152,22 @@ function renderCharm(card, data) {
 // updateHead
 // Add the required stylesheet and font to the page head
 function updateHead() {
+  let domain = ''
+  // TODO: make this a full regex pattern for js/juju-embed.js$
+  //       then use it with the .replace
+  let pattern = /juju-embed\.js$/i;
+
+  Array.from(document.getElementsByTagName("script")).forEach(function(script) {
+    if (pattern.test(script.getAttribute('src'))) {
+      domain = script.getAttribute("src").replace("js/juju-embed.js","");
+    }
+  });
+
   // Load the card stylesheet
   let css  = document.createElement('link');
   css.rel  = 'stylesheet';
   css.type = 'text/css';
-  css.href = 'scss/styles.min.css';
+  css.href = `${domain}scss/styles.min.css`;
   css.media = 'all';
   document.getElementsByTagName('head')[0].appendChild(css);
 

--- a/src/js/juju-embed.js
+++ b/src/js/juju-embed.js
@@ -58,17 +58,23 @@ function renderBundle(card, data) {
   let id = data.Id;
   let series = data.Meta['id-series'].Series;
   let revision = data.Meta.id.Revision;
-  let ownerLink = 'https://launchpad.net/~'+data.Meta['extra-info']['bzr-owner'];
-  let owner = data.Meta['extra-info']['bzr-owner'];
+  let sourceOwner = data.Meta['extra-info']['bzr-owner'];
+  let owner = data.Meta['id'].User || sourceOwner;
+  let ownerLink = 'https://launchpad.net/~'+sourceOwner;
   let detailsLink = `https://jujucharms.com/${name}/${series}/${revision}`;
-  let image = `https://api.jujucharms.com/charmstore/v4/bundle/${name}/diagram.svg`;
+  let image = `https://api.jujucharms.com/charmstore/v4/bundle/${name}-${revision}/diagram.svg`;
+  if (data.Meta['id'].User) {
+    ownerLink = 'https://jujucharms.com/u/'+owner;
+    detailsLink = `${ownerLink}/${name}`;
+    image = `https://api.jujucharms.com/charmstore/v4/~${owner}/bundle/${name}-${revision}/diagram.svg`;
+  }
   let addLink = 'https://demo.jujucharms.com/?deploy-target=' + getImageID(id);
 
   let dom = `<div class="juju-card__container bundle-card">` +
       `<a href="${detailsLink}" class="bundle-card__link">View details</a>` +
       `<header class="bundle-card__header">` +
         `<div class="bundle-card__image-container">` +
-          `<object wmode="transparent" width="100%" class="bundle-card__bundle-image" type="image/svg+xml" data="https://api.jujucharms.com/charmstore/v4/bundle/${name}-${revision}/diagram.svg"></object>` +
+          `<object wmode="transparent" width="100%" class="bundle-card__bundle-image" type="image/svg+xml" data="${image}"></object>` +
         `</div>` +
       `</header>` +
       `<main class="bundle-card__main">` +


### PR DESCRIPTION
This allows personal namespace bundles to load. There's also a small split in the logic. If we have an Owner from the API, we can route the user to the that `/u/<owner>`'s address. I've opted to follow this when we can determine it as it's a better route than just linking to launchpad.

This also allows embedding from a remote address. In previous versions the head would get a new style for `src="scss/style.css"` which will fail. It will attempt to resolve from the `js/juju-embed.js` domain.
