### PR TITLE
Direct deploy config cards

### DIFF
--- a/.install_dependencies.sh
+++ b/.install_dependencies.sh
@@ -4,7 +4,7 @@ set -e
 
 # Use 'sudo' for development setup, but simply '/usr/bin/env' in other environments
 COMMAND_PREFIX="sudo /usr/bin/env"
-GULP="/usr/bin/gulp"
+GULP="./node_modules/.bin/gulp"
 if [[ "${DEBIAN_FRONTEND}" == "noninteractive" ]] || [[ "$(whoami)" ==   "root" ]]; then
     COMMAND_PREFIX="/usr/bin/env"
     GULP="/usr/bin/env gulp"

--- a/src/index.html
+++ b/src/index.html
@@ -1,27 +1,48 @@
 <script src="juju-cards-v1.0.0.js" async></script>
 
-<div style="width:950px; margin: 20px;">
+<h1>Bundles</h1>
+<div style="width:950px; margin: 20px; float: left;">
 	<div class="juju-card" data-id="mediawiki-single"></div>
 </div>
-
-<div style="width:464px; margin: 20px;">
-	<div class="juju-card" data-id="~juju-solutions/bundle/cwr-rq"></div>
+<div style="width:950px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="mediawiki-single" data-dd></div>
 </div>
 
-<div style="width:221px; margin: 20px;">
-	<div class="juju-card" data-id="openstack-base"></div>
+<div style="width:464px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="~juju-solutions/bundle/cwr-rq"></div>
+</div>
+<div style="width:464px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="~juju-solutions/bundle/cwr-rq" data-dd></div>
 </div>
 
-<hr />
-
-<div style="width:950px; margin: 20px;">
-	<div class="juju-card" data-id="nova-compute"></div>
+<div style="width:221px; margin: 20px; float: left; clear: left;">
+  <div class="juju-card" data-id="openstack-base"></div>
+</div>
+<div style="width:221px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="openstack-base" data-dd></div>
 </div>
 
-<div style="width:464px; margin: 20px;">
+<hr style="clear: both;" />
+
+<h1>Charms</h1>
+<div style="width:950px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="nova-compute"></div>
+</div>
+<div style="width:950px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="nova-compute" data-dd></div>
+</div>
+
+<div style="width:464px; margin: 20px; float: left;">
 	<div class="juju-card" data-id="~asanjar/trusty/hdp-tez"></div>
 </div>
-
-<div style="width:221px; margin: 20px;">
-	<div class="juju-card" data-id="haproxy"></div>
+<div style="width:464px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="~asanjar/trusty/hdp-tez" data-dd></div>
 </div>
+
+<div style="width:221px; margin: 20px; float: left; clear: left;">
+  <div class="juju-card" data-id="haproxy"></div>
+</div>
+<div style="width:221px; margin: 20px; float: left;">
+  <div class="juju-card" data-id="haproxy" data-dd></div>
+</div>
+

--- a/src/js/juju-cards-v1.0.0.js
+++ b/src/js/juju-cards-v1.0.0.js
@@ -60,6 +60,12 @@ let jujuCards = () => {
     }
 
     let addLink = `${demoDomain}/?deploy-target=${getImageID(id)}`;
+    let deployTitle = 'Deploy with Juju';
+
+    if (typeof(card.dataset.dd) !== 'undefined') {
+      addLink = `${demoDomain}/?dd=${getImageID(id)}`;
+      deployTitle = 'Direct Deploy with JAAS';
+    }
 
     let dom = `<div class="juju-card__container bundle-card">` +
         `<a href="${detailsLink}" class="bundle-card__link">View details</a>` +
@@ -82,12 +88,12 @@ let jujuCards = () => {
               `</div>` +
             `</li>` +
             `<li class="bundle-card__actions-item--demo">` +
-              `<a href="${addLink}" class="bundle-card__add-button--primary">Deploy with Juju</a>` +
+              `<a href="${addLink}" class="bundle-card__add-button--primary">${deployTitle}</a>` +
             `</li>` +
           `</ul>` +
         `</main>` +
         `<footer class="bundle-card__footer">` +
-          `<a href="http://jujucharms.com"><img src="https://jujucharms.com/static/img/logos/logo.svg" alt="" class="bundle-card__footer-logo" /></a>` +
+          `<a href="http://jujucharms.com"><img src="https://jujucharms.com/static/img/logos/juju-logo.svg" alt="" class="bundle-card__footer-logo" /></a>` +
           `<p class="bundle-card__footer-note">&copy; <a href="http://www.canonical.com">Canonical Ltd</a>.</p>` +
         `</footer>` +
       `</div>`;
@@ -116,6 +122,17 @@ let jujuCards = () => {
       detailsLink = `${ownerLink}/${name}`;
     }
     let addLink = `${demoDomain}/?deploy-target=${id}`;
+    let deployTitle = 'Deploy with Juju';
+
+    if (typeof(card.dataset.dd) !== 'undefined') {
+      addLink = `${demoDomain}/?dd=${id}`;
+      deployTitle = 'Direct Deploy with JAAS';
+    }
+
+    let seriesEle = ``;
+    if (series) {
+      seriesEle = `<li class="charm-card__meta-item--series">${series}</li>`;
+    }
 
     let dom = `<div class="juju-card__container charm-card">` +
         `<a href="${detailsLink}" class="charm-card__link">View details</a>` +
@@ -124,7 +141,7 @@ let jujuCards = () => {
           `<h1 class="charm-card__title">${name}</h1>` +
           `<ul class="charm-card__meta">` +
             `<li class="charm-card__meta-item--by">by <a href="${ownerLink}">${owner}</a></li>` +
-            `<li class="charm-card__meta-item--series">${series}</li>` +
+            `${seriesEle}` +
           `</ul>` +
         `</header>` +
         `<main class="charm-card__main">` +
@@ -137,12 +154,12 @@ let jujuCards = () => {
             `</div>` +
           `</li>` +
             `<li class="charm-card__actions-item--demo">` +
-              `<a href="${addLink}" class="charm-card__add-button--primary">Deploy with Juju</a>` +
+              `<a href="${addLink}" class="charm-card__add-button--primary">${deployTitle}</a>` +
             `</li>` +
           `</ul>` +
         `</main>` +
         `<footer class="charm-card__footer">` +
-          `<a href="http://jujucharms.com"><img src="https://jujucharms.com/static/img/logos/logo.svg" alt="" class="charm-card__footer-logo" /></a>` +
+          `<a href="http://jujucharms.com"><img src="https://jujucharms.com/static/img/logos/juju-logo.svg" alt="" class="charm-card__footer-logo" /></a>` +
           `<p class="charm-card__footer-note">&copy; <a href="http://www.canonical.com">Canonical Ltd</a>.</p>` +
         `</footer>` +
       `</div>`;

--- a/src/js/juju-cards-v1.0.0.js
+++ b/src/js/juju-cards-v1.0.0.js
@@ -17,6 +17,30 @@ let jujuCards = () => {
 
   let cards = document.querySelectorAll('.' + targetClass);
 
+  // getLink
+  // Get the button link
+  const getLink = (domain, id, dd) => {
+    let addLink = `${domain}/?deploy-target=${id}`;
+
+    if (dd !== undefined) {
+      addLink = `${domain}/?dd=${id}`;
+    }
+
+    return addLink;
+  };
+
+  // getButtonText
+  // Get the button text
+  const getButtonText = (domain, id, dd) => {
+    let deployTitle = 'Deploy with Juju';
+
+    if (dd !== undefined) {
+      deployTitle = 'Deploy with JAAS';
+    }
+
+    return deployTitle;
+  };
+
   // getData
   // Concatenates the api url and fetches it
   let getData = (card, id) => {
@@ -28,7 +52,7 @@ let jujuCards = () => {
         reportError(card, response.Message);
       }
     }, card, id);
-  }
+  };
 
   // detectType
   // Checks if the element is a bundle or charm and renders the correct function
@@ -38,7 +62,7 @@ let jujuCards = () => {
     } else {
       renderCharm(card, data);
     }
-  }
+  };
 
   // renderBundle
   // Split out required data and insert card markup
@@ -59,13 +83,8 @@ let jujuCards = () => {
       image = `${apiAddress}~${owner}/bundle/${name}-${revision}/diagram.svg`;
     }
 
-    let addLink = `${demoDomain}/?deploy-target=${getImageID(id)}`;
-    let deployTitle = 'Deploy with Juju';
-
-    if (typeof(card.dataset.dd) !== 'undefined') {
-      addLink = `${demoDomain}/?dd=${getImageID(id)}`;
-      deployTitle = 'Deploy with JAAS';
-    }
+    const addLink = getLink(demoDomain, getImageID(id), card.dataset.dd);
+    const deployTitle = getButtonText(demoDomain, getImageID(id), card.dataset.dd);
 
     let dom = `<div class="juju-card__container bundle-card">` +
         `<a href="${detailsLink}" class="bundle-card__link">View details</a>` +
@@ -121,13 +140,8 @@ let jujuCards = () => {
     } else {
       detailsLink = `${ownerLink}/${name}`;
     }
-    let addLink = `${demoDomain}/?deploy-target=${id}`;
-    let deployTitle = 'Deploy with Juju';
-
-    if (typeof(card.dataset.dd) !== 'undefined') {
-      addLink = `${demoDomain}/?dd=${id}`;
-      deployTitle = 'Deploy with JAAS';
-    }
+    const addLink = getLink(demoDomain, getImageID(id), card.dataset.dd);
+    const deployTitle = getButtonText(demoDomain, getImageID(id), card.dataset.dd);
 
     let seriesEle = ``;
     if (series) {

--- a/src/js/juju-cards-v1.0.0.js
+++ b/src/js/juju-cards-v1.0.0.js
@@ -64,7 +64,7 @@ let jujuCards = () => {
 
     if (typeof(card.dataset.dd) !== 'undefined') {
       addLink = `${demoDomain}/?dd=${getImageID(id)}`;
-      deployTitle = 'Direct Deploy with JAAS';
+      deployTitle = 'Deploy with JAAS';
     }
 
     let dom = `<div class="juju-card__container bundle-card">` +
@@ -126,7 +126,7 @@ let jujuCards = () => {
 
     if (typeof(card.dataset.dd) !== 'undefined') {
       addLink = `${demoDomain}/?dd=${id}`;
-      deployTitle = 'Direct Deploy with JAAS';
+      deployTitle = 'Deploy with JAAS';
     }
 
     let seriesEle = ``;

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -20,6 +20,7 @@
     background: $white;
     width: 100%;
     box-sizing: border-box;
+    border-radius: 2px;
 
     &__error {
       transition: opacity .5s;

--- a/src/scss/_bundle.scss
+++ b/src/scss/_bundle.scss
@@ -103,6 +103,7 @@
       background-position: 10px center;
       box-sizing: border-box;
       border: 1px solid $light-grey;
+      border-radius: 2px;
       padding: 12px 10px 12px 35px;
       width: 100%;
       color: $mid-grey;

--- a/src/scss/_charm.scss
+++ b/src/scss/_charm.scss
@@ -37,7 +37,7 @@
       margin-right: 20px;
       width: 50px;
       height: 50px;
-      border-radius: 50px;
+      border-radius: 50%;
     }
 
     &__title {

--- a/src/scss/_charm.scss
+++ b/src/scss/_charm.scss
@@ -37,6 +37,7 @@
       margin-right: 20px;
       width: 50px;
       height: 50px;
+      border-radius: 50px;
     }
 
     &__title {
@@ -103,6 +104,7 @@
       background-position: 10px center;
       box-sizing: border-box;
       border: 1px solid $light-grey;
+      border-radius: 2px;
       padding: 12px 10px 12px 35px;
       width: 100%;
       color: $mid-grey;


### PR DESCRIPTION
- Updated .install_dependencies.sh to use local gulp
- Updated index.html to include DD versions of the same cards.
- [juju-cards.js] Added data-dd option to html to enable direct deploy cards, generate different link and button text for direct deploy cards. Only show series li if series is defined.
- [_base.scss] Added border radius to cards
- [_bundle.scss, _charm.scss] Added border radius to actions-field.