### PR TITLE
Fix charm button wrapping

### DIFF
--- a/src/scss/_charm.scss
+++ b/src/scss/_charm.scss
@@ -227,11 +227,6 @@
         }
       }
 
-      &__actions-item--demo,
-      &__actions-item--details {
-        @extend %half-half;
-      }
-
       &__actions-field,
       &__actions-label,
       &__actions-copy-to-clipboard {
@@ -255,6 +250,11 @@
 
       &__main {
         margin-right: 0;
+      }
+
+      &__actions-item--demo,
+      &__actions-item--details {
+        @extend %half-half;
       }
 
       &__actions-item--demo,


### PR DESCRIPTION
QA:
- open the demo link (or run the project - instructions here: https://github.com/CanonicalLtd/juju-cards#usage)
- check that the medium size charm cards wrap the input and button onto separate lines like the medium bundle cards do (see the broken buttons here: https://github.com/canonical-web-and-design/jaas.ai/issues/255).