### PR TITLE
Remove inline css source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "LGPL-3.0",
   "scripts": {
     "build-js": "babel src --out-dir build",
-    "build-css": "node-sass --include-path node_modules src/scss --output build/css && postcss --use autoprefixer --replace 'build/css/*.css' && postcss --use cssnano --dir build/css 'build/css/*.css'",
+    "build-css": "node-sass --include-path node_modules src/scss --output build/css && postcss --use autoprefixer --replace 'build/css/*.css' --no-map && postcss --use cssnano --dir build/css 'build/css/*.css' --no-map",
     "build-html": "cp src/index.html build",
     "build": "yarn run build-css && yarn run build-js && yarn run build-html",
     "clean": "rm -r build; rm -r node_modules",


### PR DESCRIPTION
- Run `npm install`
- Run `npm run build`
- Check that the outputted file in `build/css` does not contain inline source maps.